### PR TITLE
ci(NuGet): Reworking the code signing mechanism. 

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "sign": {
+      "version": "0.9.1-beta.26330.1",
+      "commands": [
+        "sign"
+      ]
+    }
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,23 +92,6 @@ jobs:
       - name: Validate NuGet package signature
         run: dotnet nuget verify "${{ github.workspace }}/artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg"
         
-      # sign package:
-#      - name: Restore signing certificate
-#        env:
-#            SIGNING_CERTIFICATE_2023_2026: ${{ secrets.SIGNING_CERTIFICATE_2023_2026 }}
-#        run: |
-#          echo $SIGNING_CERTIFICATE_2023_2026 | base64 --decode > signingcert.pfx
-
-#      - name: Sign NuGet package
-#        env:
-#            SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
-#            SIGNING_CERTIFICATE_TIMESTAMP_URL: ${{ vars.SIGNING_CERTIFICATE_TIMESTAMP_URL }}
-#        run: |
-#            dotnet nuget sign "./artifacts/*.nupkg" \
-#              --certificate-path signingcert.pfx \
-#              --certificate-password "${SIGNING_CERTIFICATE_PASSWORD}" \
-#              --timestamper "${SIGNING_CERTIFICATE_TIMESTAMP_URL}"
-
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,20 @@ name: Publish NuGet Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "default: 0.7.2-alpha.0"
+        required: false
+        default: ""
+      angular_regular_version:
+        description: "Angular regular version | default: 21.2.0 (leave empty to skip)"
+        required: false
+        default: ""
 
 env:
-  VERSION: ${{ github.ref_name }}
+  VERSION: ${{ inputs.version || github.ref_name }}
+  BUILD_CONFIGURATION: Release
 
 jobs:
   publish:
@@ -13,6 +24,9 @@ jobs:
     environment: NuGet Deploy
     permissions:
       id-token: write  # enable GitHub OIDC token issuance for this job
+      contents: read
+      attestations: write
+
 
     steps:
       - uses: actions/checkout@v4
@@ -37,35 +51,89 @@ jobs:
         run: dotnet restore src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj
 
       - name: Build
-        run: dotnet build src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration Release -p:Version=${VERSION} -p:RunNodeBuild=false -p:GeneratePackageOnBuild=false
+        run: dotnet build src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration {{ env.BUILD_CONFIGURATION }} -p:Version=${VERSION} -p:RunNodeBuild=false -p:GeneratePackageOnBuild=false
+
+      - name: Install Sign CLI
+        run: dotnet tool install --tool-path ./sign --prerelease sign
+
+      - name: Authenticate to Azure
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign DLLs
+        shell: pwsh
+        run: >
+          ./sign/sign code azure-key-vault "src/IgniteUI.Blazor.GridLite/**/*.dll"
+          --base-directory "${{ github.workspace }}/bin/${{ env.BUILD_CONFIGURATION }}"
+          --azure-key-vault-url "${{ secrets.AZURE_KEYVAULT_URL }}"
+          --azure-key-vault-certificate "${{ secrets.AZURE_KEYVAULT_CERTIFICATE }}"
+
+      - name: Validate DLL signatures
+        shell: pwsh
+        run: |
+          $dlls = Get-ChildItem -Path "${{ github.workspace }}\bin\${{ env.BUILD_CONFIGURATION }}" -Filter "*.dll" -Recurse
+          $failed = @()
+          foreach ($dll in $dlls) {
+            $sig = Get-AuthenticodeSignature $dll.FullName
+            if ($sig.Status -ne 'Valid') {
+              $failed += $dll.FullName
+            }
+          }
+          if ($failed.Count -gt 0) {
+            Write-Error "Unsigned DLLs found:`n$($failed -join "`n")"
+            exit 1
+          }
+          Write-Host "All DLLs signed successfully."
 
       - name: Pack NuGet package
-        run: dotnet pack src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration Release --no-build --no-restore -p:PackageVersion=${VERSION} -o ./artifacts
-
-      # sign package:
-      - name: Restore signing certificate
-        env:
-            SIGNING_CERTIFICATE_2023_2026: ${{ secrets.SIGNING_CERTIFICATE_2023_2026 }}
-        run: |
-          echo $SIGNING_CERTIFICATE_2023_2026 | base64 --decode > signingcert.pfx
+        run: dotnet pack src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration {{ env.BUILD_CONFIGURATION }} --no-build --no-restore -p:PackageVersion=${VERSION} -o ./artifacts
 
       - name: Sign NuGet package
-        env:
-            SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
-            SIGNING_CERTIFICATE_TIMESTAMP_URL: ${{ vars.SIGNING_CERTIFICATE_TIMESTAMP_URL }}
-        run: |
-            dotnet nuget sign "./artifacts/*.nupkg" \
-              --certificate-path signingcert.pfx \
-              --certificate-password "${SIGNING_CERTIFICATE_PASSWORD}" \
-              --timestamper "${SIGNING_CERTIFICATE_TIMESTAMP_URL}"
+        shell: pwsh
+        run: >
+          ./sign/sign code azure-key-vault "*.nupkg"
+          --base-directory "${{ github.workspace }}/artifacts"
+          --azure-key-vault-url "${{ secrets.AZURE_KEYVAULT_URL }}"
+          --azure-key-vault-certificate "${{ secrets.AZURE_KEYVAULT_CERTIFICATE }}"
 
+      - name: Validate NuGet package signature
+        run: dotnet nuget verify "${{ github.workspace }}/artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg"
+        
+      # sign package:
+#      - name: Restore signing certificate
+#        env:
+#            SIGNING_CERTIFICATE_2023_2026: ${{ secrets.SIGNING_CERTIFICATE_2023_2026 }}
+#        run: |
+#          echo $SIGNING_CERTIFICATE_2023_2026 | base64 --decode > signingcert.pfx
+
+#      - name: Sign NuGet package
+#        env:
+#            SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.SIGNING_CERTIFICATE_PASSWORD }}
+#            SIGNING_CERTIFICATE_TIMESTAMP_URL: ${{ vars.SIGNING_CERTIFICATE_TIMESTAMP_URL }}
+#        run: |
+#            dotnet nuget sign "./artifacts/*.nupkg" \
+#              --certificate-path signingcert.pfx \
+#              --certificate-password "${SIGNING_CERTIFICATE_PASSWORD}" \
+#              --timestamper "${SIGNING_CERTIFICATE_TIMESTAMP_URL}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: Generated NuGet Package 
+          path: ${{ github.workspace }}/artifacts
+          retention-days: 1
+          
       # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841   # v1
         id: login
         with:
           user: ${{ secrets.INFRAGISTICS_NUGET_ORG_USER }}
 
       # Push the package
       - name: NuGet push
+        if: false # temp disable while working in the branch
         run: dotnet nuget push artifacts/IgniteUI.Blazor.GridLite.${VERSION}.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Build
         run: dotnet build src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration ${{ env.BUILD_CONFIGURATION }} -p:Version=${{ env.VERSION }} -p:RunNodeBuild=false -p:GeneratePackageOnBuild=false
 
-      - name: Install Sign CLI
-        run: dotnet tool install --tool-path ./sign --prerelease sign
-
       - name: Authenticate to Azure
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     environment: NuGet Deploy
     permissions:
       id-token: write  # enable GitHub OIDC token issuance for this job

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Validate DLL signatures
         shell: pwsh
         run: |
-          $dlls = Get-ChildItem -Path "${{ github.workspace }}\bin\${{ env.BUILD_CONFIGURATION }}" -Filter "*.dll" -Recurse
+          $dlls = Get-ChildItem -Path "${{ github.workspace }}/src/IgniteUI.Blazor.GridLite/bin/${{ env.BUILD_CONFIGURATION }}" -Filter "*.dll" -Recurse
           $failed = @()
           foreach ($dll in $dlls) {
             $sig = Get-AuthenticodeSignature $dll.FullName

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,10 @@ jobs:
         shell: pwsh
         run: |
           $dlls = Get-ChildItem -Path "${{ github.workspace }}/src/IgniteUI.Blazor.GridLite/bin/${{ env.BUILD_CONFIGURATION }}" -Filter "*.dll" -Recurse
+          if (-not $dlls -or $dlls.Count -eq 0) {
+            Write-Error "No DLLs found under '${{ github.workspace }}/src/IgniteUI.Blazor.GridLite/bin/${{ env.BUILD_CONFIGURATION }}' to validate."
+            exit 1
+          }
           $failed = @()
           foreach ($dll in $dlls) {
             $sig = Get-AuthenticodeSignature $dll.FullName

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,19 +3,9 @@ name: Publish NuGet Package
 on:
   release:
     types: [created]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "default: 0.7.2-alpha.0"
-        required: false
-        default: ""
-      angular_regular_version:
-        description: "Angular regular version | default: 21.2.0 (leave empty to skip)"
-        required: false
-        default: ""
 
 env:
-  VERSION: ${{ inputs.version || github.ref_name }}
+  VERSION: ${{ github.ref_name }}
   BUILD_CONFIGURATION: Release
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         run: dotnet restore src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj
 
       - name: Build
-        run: dotnet build src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration ${BUILD_CONFIGURATION} -p:Version=${VERSION} -p:RunNodeBuild=false -p:GeneratePackageOnBuild=false
+        run: dotnet build src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration ${{ env.BUILD_CONFIGURATION }} -p:Version=${{ env.VERSION }} -p:RunNodeBuild=false -p:GeneratePackageOnBuild=false
 
       - name: Install Sign CLI
         run: dotnet tool install --tool-path ./sign --prerelease sign
@@ -89,7 +89,7 @@ jobs:
           Write-Host "All DLLs signed successfully."
 
       - name: Pack NuGet package
-        run: dotnet pack src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration {{ env.BUILD_CONFIGURATION }} --no-build --no-restore -p:PackageVersion=${VERSION} -o ./artifacts
+        run: dotnet pack src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --no-restore -p:PackageVersion=${{ env.VERSION }} -o ./artifacts
 
       - name: Sign NuGet package
         shell: pwsh
@@ -136,4 +136,4 @@ jobs:
       # Push the package
       - name: NuGet push
         if: false # temp disable while working in the branch
-        run: dotnet nuget push artifacts/IgniteUI.Blazor.GridLite.${VERSION}.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source "https://api.nuget.org/v3/index.json"
+        run: dotnet nuget push artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,3 +106,6 @@ jobs:
       # Push the package
       - name: NuGet push
         run: dotnet nuget push artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source "https://api.nuget.org/v3/index.json"
+
+      - name: Publish to NuGet.org
+        run: dotnet nuget push "${{ github.workspace }}/artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Sign DLLs
         shell: pwsh
         run: >
-          ./sign/sign code azure-key-vault "src/IgniteUI.Blazor.GridLite/**/*.dll"
-          --base-directory "${{ github.workspace }}/bin/${{ env.BUILD_CONFIGURATION }}"
+          ./sign/sign code azure-key-vault "**/*.dll"
+          --base-directory "${{ github.workspace }}/src/IgniteUI.Blazor.GridLite/bin/${{ env.BUILD_CONFIGURATION }}"
           --azure-key-vault-url "${{ secrets.AZURE_KEYVAULT_URL }}"
           --azure-key-vault-certificate "${{ secrets.AZURE_KEYVAULT_CERTIFICATE }}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
     permissions:
       id-token: write  # enable GitHub OIDC token issuance for this job
       contents: read
-      attestations: write
-
 
     steps:
       - uses: actions/checkout@v4
@@ -91,14 +89,7 @@ jobs:
 
       - name: Validate NuGet package signature
         run: dotnet nuget verify "${{ github.workspace }}/artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg"
-        
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: Generated NuGet Package 
-          path: ${{ github.workspace }}/artifacts
-          retention-days: 1
-          
+                 
       # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841   # v1
@@ -108,5 +99,4 @@ jobs:
 
       # Push the package
       - name: NuGet push
-        if: false # temp disable while working in the branch
         run: dotnet nuget push artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,6 +106,3 @@ jobs:
       # Push the package
       - name: NuGet push
         run: dotnet nuget push artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source "https://api.nuget.org/v3/index.json"
-
-      - name: Publish to NuGet.org
-        run: dotnet nuget push "${{ github.workspace }}/artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,6 @@ jobs:
 
       - name: Validate NuGet package signature
         run: dotnet nuget verify "${{ github.workspace }}/artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg"
-                 
       # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841   # v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         run: dotnet restore src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj
 
       - name: Build
-        run: dotnet build src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration {{ env.BUILD_CONFIGURATION }} -p:Version=${VERSION} -p:RunNodeBuild=false -p:GeneratePackageOnBuild=false
+        run: dotnet build src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration ${BUILD_CONFIGURATION} -p:Version=${VERSION} -p:RunNodeBuild=false -p:GeneratePackageOnBuild=false
 
       - name: Install Sign CLI
         run: dotnet tool install --tool-path ./sign --prerelease sign

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj
 
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+
       - name: Build
         run: dotnet build src/IgniteUI.Blazor.GridLite/IgniteUI.Blazor.GridLite.csproj --configuration ${{ env.BUILD_CONFIGURATION }} -p:Version=${{ env.VERSION }} -p:RunNodeBuild=false -p:GeneratePackageOnBuild=false
 


### PR DESCRIPTION
Use the new approach to signing code in the repo, aligning it with the recommendations from Microsoft, a.k.a code-signing the DLLs as well as the NuGet package.

The code signing mechanism works on any Windows runner, but unfortunately it requires Windows OS binaries to work, so ubuntu-latest is no longer viable if we want to keep the workflow with just 1 job.

Reference guide from Barry from MS: https://idunno.org/net-code-nupkg-signing-in-github-actions/
