### PR TITLE
ci: Tweak code signing authentication and logging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,8 @@ jobs:
           --base-directory "${{ github.workspace }}/src/IgniteUI.Blazor.GridLite/bin/${{ env.BUILD_CONFIGURATION }}"
           --azure-key-vault-url "${{ secrets.AZURE_KEYVAULT_URL }}"
           --azure-key-vault-certificate "${{ secrets.AZURE_KEYVAULT_CERTIFICATE }}"
+          --azure-credential-type azure-cli
+          --verbosity Warning
 
       - name: Validate DLL signatures
         shell: pwsh
@@ -90,6 +92,8 @@ jobs:
           --base-directory "${{ github.workspace }}/artifacts"
           --azure-key-vault-url "${{ secrets.AZURE_KEYVAULT_URL }}"
           --azure-key-vault-certificate "${{ secrets.AZURE_KEYVAULT_CERTIFICATE }}"
+          --azure-credential-type azure-cli
+          --verbosity Warning
 
       - name: Validate NuGet package signature
         run: dotnet nuget verify "${{ github.workspace }}/artifacts/IgniteUI.Blazor.GridLite.${{ env.VERSION }}.nupkg"


### PR DESCRIPTION
Explicitly set `--azure-credential-type azure-cli` in order to avoid these "errors as info" messages when invokin the `sign` tool:
(core reason is that it tries an ordered list of authentication methods that fail until it reaches the one compatible with the azure/login action's context of setting the OIDC token for the azure cli to use).

Also, reduce sign tool log output in order to avoid disclosing any details that we also don't need to look at during every execution.