### PR TITLE
ci: Add Dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"  # scans .github/workflows/ automatically
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 14  # only propose versions released ≥14 days ago
+    groups:
+      github-actions:
+        applies-to: version-updates  # security updates bypass grouping — each gets its own fast-track PR
+        patterns:
+          - "*"  # batch all version updates into a single PR


### PR DESCRIPTION
Follow the best security practices in setting up 1st party GitHub actions updates via dependabot.

Reference: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions